### PR TITLE
Call by name limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Assert.assertEquals(Some(List(66300, 612300)), result)
 ```
 
 ## Limitation
-`Each` cannot perform proper transform monadic expression which act as a `call-by-name` parameter, it was discussed #37.
+`Each` cannot perform proper transform of monadic expression which act as a `call-by-name` parameter, it was discussed [#37](https://github.com/ThoughtWorksInc/each/issues/37).
 
 ```scala
 val err = Future.failed(new Exception("foo"))

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Assert.assertEquals(Some(List(66300, 612300)), result)
 ```
 
 ## Limitation
-`Each` cannot perform proper transform of monadic expression which act as a `call-by-name` parameter, it was discussed [#37](https://github.com/ThoughtWorksInc/each/issues/37).
+`Each` cannot perform proper transformation of monadic expression which act as a `call-by-name` parameter, it was discussed [#37](https://github.com/ThoughtWorksInc/each/issues/37).
 
 ```scala
 val err = Future.failed(new Exception("foo"))

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ val baz = monadic[Future] {
   opt.getOrElse(err.each)
 }
 ```
-`baz` will faill.
+Result of `baz` will fail.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ val result = monadic[Option] {
 Assert.assertEquals(Some(List(66300, 612300)), result)
 ```
 
+## Limitation
+`Each` cannot perform proper transform monadic expression which act as a `call-by-name` parameter, it was discussed #37.
+
+```scala
+val err = Future.failed(new Exception("foo"))
+val opt = Some("bar")
+val baz = monadic[Future] {
+  opt.getOrElse(err.each)
+}
+```
+`baz` will faill.
 
 ## Links
 


### PR DESCRIPTION
Add `call-by-name` limitation within `README` file