### PR TITLE
remove duplicate scalamacros dependency etc

### DIFF
--- a/core/build.sbt.shared
+++ b/core/build.sbt.shared
@@ -10,8 +10,6 @@ libraryDependencies += "org.scalaz" %%% "scalaz-core" % "7.2.6"
 
 libraryDependencies += "org.scalaz" %%% "scalaz-effect" % "7.2.6"
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 
 libraryDependencies += "com.thoughtworks.enableIf" %% "enableif" % "1.1.2" % Test

--- a/core/src/main/scala/com/thoughtworks/sde/core/MonadicFactory.scala
+++ b/core/src/main/scala/com/thoughtworks/sde/core/MonadicFactory.scala
@@ -73,7 +73,7 @@ object MonadicFactory {
 
       final case class OpenTree(prefix: CpsTree, parameter: ValDef, inner: CpsTree) extends CpsTree {
 
-        override final def toReflectTree: Tree = {
+        override def toReflectTree: Tree = {
           inner match {
             case PlainTree(plain, _) => {
               Apply(
@@ -95,9 +95,9 @@ object MonadicFactory {
           }
         }
 
-        override final def tpe = inner.tpe
+        override def tpe = inner.tpe
 
-        override final def flatMap(f: Tree => CpsTree): CpsTree = {
+        override def flatMap(f: Tree => CpsTree): CpsTree = {
           new OpenTree(prefix, parameter, inner.flatMap(f))
         }
 
@@ -105,23 +105,23 @@ object MonadicFactory {
 
       final case class BlockTree(prefix: List[Tree], tail: CpsTree) extends CpsTree {
 
-        override final def tpe = tail.tpe
+        override def tpe = tail.tpe
 
-        override final def toReflectTree: Tree = {
+        override def toReflectTree: Tree = {
           Block(prefix, tail.toReflectTree)
         }
 
-        override final def flatMap(f: Tree => CpsTree): CpsTree = {
+        override def flatMap(f: Tree => CpsTree): CpsTree = {
           BlockTree(prefix, tail.flatMap(f))
         }
 
       }
 
-      final case class MonadTree(reflectTree: Tree, override final val tpe: Type) extends CpsTree {
+      final case class MonadTree(reflectTree: Tree, override val tpe: Type) extends CpsTree {
 
-        override final def toReflectTree = reflectTree
+        override def toReflectTree = reflectTree
 
-        override final def flatMap(f: Tree => CpsTree): CpsTree = {
+        override def flatMap(f: Tree => CpsTree): CpsTree = {
           val newId = TermName(c.freshName("element"))
           OpenTree(MonadTree.this, ValDef(Modifiers(PARAM), newId, TypeTree(tpe), EmptyTree), f(Ident(newId)))
         }
@@ -130,13 +130,13 @@ object MonadicFactory {
 
       final case class PlainTree(tree: Tree, tpe: Type) extends CpsTree {
 
-        override final def toReflectTree: Tree = {
+        override def toReflectTree: Tree = {
           Apply(
             Select(monadTree, TermName("point")),
             List(tree))
         }
 
-        override final def flatMap(f: Tree => CpsTree): CpsTree = {
+        override def flatMap(f: Tree => CpsTree): CpsTree = {
           f(tree)
         }
 
@@ -567,7 +567,7 @@ object MonadicFactory {
               }
             }
           }
-          case EmptyTree | _: Return | _: New | _: Ident | _: Literal | _: Super | _: This | _: TypTree | _: New | _: TypeDef | _: Function | _: DefDef | _: ClassDef | _: ModuleDef | _: Import | _: ImportSelector => {
+          case EmptyTree | _: Return | _: New | _: Ident | _: Literal | _: Super | _: This | _: TypTree | _: TypeDef | _: Function | _: DefDef | _: ClassDef | _: ModuleDef | _: Import | _: ImportSelector => {
             new PlainTree(origin, origin.tpe)
           }
         }

--- a/source/src/main/scala/com/thoughtworks/sde/source.scala
+++ b/source/src/main/scala/com/thoughtworks/sde/source.scala
@@ -243,13 +243,13 @@ object source {
 
     private[SourceSeq] final case object Empty extends SourceSeq[Nothing] {
 
-      override final def isEmpty: Boolean = true
+      override def isEmpty: Boolean = true
 
-      override final def head: Nothing = {
+      override def head: Nothing = {
         throw new NoSuchElementException("head of empty list")
       }
 
-      override final def tail: Nothing = {
+      override def tail: Nothing = {
         throw new UnsupportedOperationException("tail of empty list")
       }
 
@@ -259,9 +259,9 @@ object source {
 
     private[SourceSeq] final case class NonEmpty[+A](override val head: A, tailSource: Source[_ <: A, _]) extends SourceSeq[A] {
 
-      override final def isEmpty: Boolean = false
+      override def isEmpty: Boolean = false
 
-      override final def tail: SourceSeq[A] = {
+      override def tail: SourceSeq[A] = {
         sourceToSeq(tailSource)
       }
 


### PR DESCRIPTION
Change:
- remove duplicate scalamacros dependency in `core/build.sbt`
- remove unnecessary finals in final class' fields and parameters
- remove a duplicate `_:New` pattern
